### PR TITLE
Fix compatibility with newest version of grunt.js

### DIFF
--- a/GruntFile.js
+++ b/GruntFile.js
@@ -4,20 +4,21 @@ module.exports = function (grunt) {
 
     // Project configuration.
     grunt.initConfig({
-        test: {
-            files: ['test/**/*.js']
-        },
-
-        lint: {
-            files: ['grunt.js', 'tasks/**/*.js', 'test/**/*.js']
+        nodeunit: {
+            all: ['test/**/*.js']
         },
 
         watch: {
-            files: '<config:lint.files>',
-            tasks: 'default'
+            gruntfile: {
+                files: ['<%= jshint.gruntfile %>'],
+                tasks: ['jshint:gruntfile']
+            }
         },
 
         jshint: {
+            files: {
+                src: ['grunt.js', 'tasks/**/*.js', 'test/**/*.js']
+            },
             options: {
                 'bitwise'   : true,
                 'camelcase' : true,
@@ -86,10 +87,11 @@ module.exports = function (grunt) {
         }
     });
 
-    // Load local tasks.
-    grunt.loadTasks('tasks');
+    // Load tasks.
+    grunt.loadNpmTasks('grunt-contrib-watch');
+    grunt.loadNpmTasks('grunt-contrib-nodeunit');
+    grunt.loadNpmTasks('grunt-contrib-jshint');
 
     // Default task.
-    grunt.registerTask('default', 'lint test');
-
+    grunt.registerTask('default', ['jshint', 'nodeunit']);
 };

--- a/package.json
+++ b/package.json
@@ -30,7 +30,10 @@
     "test": "grunt test"
   },
   "devDependencies": {
-    "grunt": "~0.3.17"
+    "grunt": "~0.4.0",
+    "grunt-contrib-jshint": "0.1.1rc6",
+    "grunt-contrib-watch": "0.2.0rc7",
+    "grunt-contrib-nodeunit": "0.1.2"
   },
   "keywords": [
     "gruntplugin",
@@ -46,6 +49,6 @@
   "dependencies": {
     "groundskeeper": "~0.1.1",
     "grunt-lib-contrib": "~0.3.1",
-    "grunt": "~0.3.17"
+    "grunt": "~0.4.0"
   }
 }

--- a/tasks/groundskeeper.js
+++ b/tasks/groundskeeper.js
@@ -14,16 +14,14 @@ module.exports = function (grunt) {
         // Depedencies
         var path = require('path'),
             groundskeeper = require('groundskeeper'),
-            helpers = require('grunt-lib-contrib').init(grunt),
             cleaner = {},
             self = this; // Too lazy to .bind a bunch of functions
 
-
-        grunt.file.expand(this.file.src).forEach(function (file) {
+        this.filesSrc.forEach(function (file) {
             var dest = (!this.data.keepStructure) ?
-                    this.file.dest + path.sep + path.basename(file) :
+                    this.files.dest + path.sep + path.basename(file) :
                     path.resolve(
-                        this.file.dest,
+                        this.files.dest,
                         file.split(path.sep)
                             .splice(1)
                             .join(path.sep)
@@ -33,7 +31,5 @@ module.exports = function (grunt) {
                 grunt.file.write(dest, cleaner.toString());
 
         }, this);
-
     });
-
 };


### PR DESCRIPTION
This should make grunt-groundskeeper compatible with the newest syntax introduced in version 0.4.0.
